### PR TITLE
Extended utility.Timer() such that you can't start multiple tasks at …

### DIFF
--- a/cog/experience.py
+++ b/cog/experience.py
@@ -1,6 +1,6 @@
 import discord, db_user_interface
 from discord.ext import commands
-from utility import timer, Timer, make_simple_embed, PARSE_CLASS_VAR
+from utility import Timer, make_simple_embed, PARSE_CLASS_VAR
 from copy import copy
 
 import customs.cog
@@ -54,7 +54,7 @@ class Experience(customs.cog.Cog):
             return
         
         Experience._user_cooldown_[message.author.id] = Timer(self.user_cooldowned, seconds=_EXP_COOLDOWN)
-        await Experience._user_cooldown_[message.author.id].start(message.author)
+        Experience._user_cooldown_[message.author.id].start(message.author)
 
         db_user_interface.modify_exp(self.bot.db_user, message.author.id, _EXP_BASE)
     

--- a/cog/frogs.py
+++ b/cog/frogs.py
@@ -203,7 +203,7 @@ class Frogs(customs.cog.Cog):
 
         for i in range(len(channel_ids)):
             spawner = self.Spawner(ctx.guild.id, channel_ids[i], rates[i], copy(self.frog_timer), self)
-            await spawner.start()
+            spawner.start()
             Frogs._frogs_spawner_[ctx.guild.id].append(spawner)
 
         # Message
@@ -281,7 +281,7 @@ class Frogs(customs.cog.Cog):
             if spawner.channel_id == channel_id:
                 spawner.set_base_rate(new_rate)
                 spawner.stop()
-                await spawner.start()
+                spawner.start()
                 
 
         frogs_settings['channel_rates'] = list(zip(channels, rates))
@@ -306,7 +306,7 @@ class Frogs(customs.cog.Cog):
 
         if frogs_settings['active']:
             spawner = self.Spawner(ctx.guild.id, channel, rate, copy(self.frog_timer), self)
-            await spawner.start()
+            spawner.start()
             Frogs._frogs_spawner_[ctx.guild.id].append(spawner)
 
         frogs_settings['channel_rates'].append([channel.id, rate])        

--- a/utility.py
+++ b/utility.py
@@ -1,4 +1,4 @@
-import re, time
+import re
 
 import emoji
 import discord

--- a/utility.py
+++ b/utility.py
@@ -1,4 +1,4 @@
-import re
+import re, time
 
 import emoji
 import discord
@@ -32,24 +32,54 @@ class Timer():
         self._callback = callback
         self._duration = seconds + 60*minutes + 3600*hours
         self._task = None
+        self._is_running = False
 
-    async def start(self, *args, **kwargs):
+    def start(self, *args, **kwargs):
+        if self._is_running:
+            raise RuntimeError('Timer is already running and is not yet complete!')
+
         self._task = asyncio.create_task(self._start(*args, **kwargs))
+        self._is_running = True
+
+        return self._task
 
     async def _start(self, *args, **kwargs):
         await asyncio.sleep(self._duration)
+        self._is_running = False
 
         if asyncio.iscoroutinefunction(self._callback):
             await self._callback(*args, **kwargs)
         else:
             self._callback(*args, **kwargs)
 
-    async def restart(self, *args, **kwargs):
-        self._task.add_done_callback(self.start(*args, **kwargs))
+    def restart(self, *args, **kwargs):
+        '''
+        Because of the nature of task scheduling, do not restart the timer and immediately cancel it. This method merely
+        schedules for a restart when it is safe to do so. Meaning in order for it to actually be scheduled, we need to
+        regularly do context switches until it is scheduled. Typically this is done naturally with await's, but if not 
+        enough prevelant or you want to ensure that the timer has already been restarted, try the following:
+
+            await asyncio.tasks.wait([task], return_when=asyncio.ALL_COMPLETED)
+
+        Where [task] is the task(s) you want to ensure have restarted. task is returned from start(). The code resumes
+        operation when the task is either cancelled or finishes.
+
+        restart() does not return the _task.
+        '''
+
+        def restart_when_cancelled(future, args=args, kwargs=kwargs):
+            self._task.remove_done_callback(restart_when_cancelled)
+            self.start(*args, **kwargs)
+
+        self._task.add_done_callback(restart_when_cancelled)
+        self.cancel()
+        
+    def cancel(self):
+        self._is_running = False
         self._task.cancel()
 
-    async def cancel(self):
-        self._task.cancel()
+    def get_currently_running_task(self):
+        return self._task
 
 
 class ReadOnlyDict(dict):


### PR DESCRIPTION
…once... plus more

Restart will now schedule a restart rather than restart immediately. This is to ensure improve concurrency, however comes with the problem of calling cancel immediately after restart(). If you ever need to do this, I left in-code comments on how to handle it.